### PR TITLE
remove unnecessary `RefCell<Option>` around reactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["plhk"]
 
 [dependencies]
-futures = "0.2"
+futures-preview = "*"
 libc = "0.2"
 log = "0.4"
 pretty_env_logger = "0.2"


### PR DESCRIPTION
When the Reactor is `None`, you either ignore it or panic, which means that for the most part the reactor is assumed to exist. By just creating it in the thread local storage you ensure the assumption is correct.

As the [documentation](https://doc.rust-lang.org/std/thread/struct.LocalKey.html#method.with) states, the TLS key is lazily initialized anyway so using an `Option` is redundant.

The only reason `RefCell` is used is to create the reactor once on the creation of `Core`, while the cost of run-time borrow-checking (and `None` check) exists on every use of the reactor.