### PR TITLE
Remove redundant interior mutablity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["plhk"]
 
 [dependencies]
-futures = "0.2"
+futures-preview = "0.2"
 libc = "0.2"
 log = "0.4"
 pretty_env_logger = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,22 +35,8 @@ thread_local! {
     static REACTOR: Rc<InnerEventLoop> = Rc::new(InnerEventLoop::new());
 }
 
-// The Core is just a wrapper around InnerEventLoop
-// where everything happens.
-#[derive(Clone)]
-pub struct Core(Rc<InnerEventLoop>);
-
-impl Core {
-    // Create the inner event loop and save it into thread local
-    pub fn new() -> Self {
-        let reactor = REACTOR.with(|ev| ev.clone());
-        Core(reactor)
-    }
-
-    // delegate to inner loop
-    pub fn run<F: Future<Item = (), Error = ()> + 'static>(self, f: F) {
-        self.0.run(f)
-    }
+pub fn run<F: Future<Item = (), Error = ()> + 'static>(f: F) {
+    REACTOR.with(|reactor| reactor.run(f))
 }
 
 // Our waker Token. It stores the index of the future in the wait queue
@@ -419,7 +405,6 @@ mod tests {
                 })
             })
             .then(|_| Ok(()));
-        let core = Core::new();
-        core.run(future);
+        run(future);
     }
 }


### PR DESCRIPTION
According to the [documentation](https://doc.rust-lang.org/std/thread/struct.LocalKey.html#method.with), thread locals are already lazily initialized so the outer `RefCell<Option>` is unnecessary.

The fields of the reactor already have interior mutablity, so the inner `RefCell` isn't needed as well, especially since it's easier to see that all mutable borrows of the fields are local to the event loops methods and so won't happen concurrently, than the struct itself which is available in multiple contexts.  